### PR TITLE
feat: change background color to enterprise red

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
     line-height: 1.6;
     color: #333;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #C41E3A 0%, #8B0000 100%);
     min-height: 100vh;
 }
 


### PR DESCRIPTION
Changes the background color from blue-purple gradient to enterprise red gradient as requested in issue #2.

- Updated background gradient colors in style.css
- Uses professional corporate red colors (#C41E3A to #8B0000)
- Maintains gradient effect for visual appeal

Closes #2

Generated with [Claude Code](https://claude.ai/code)